### PR TITLE
Добавить конструктор BH в прототип BH

### DIFF
--- a/lib/bh.js
+++ b/lib/bh.js
@@ -549,7 +549,7 @@ function BH() {
 }
 
 BH.prototype = {
-    contructor: BH,
+    constructor: BH,
 
     /**
      * Задает опции шаблонизации.

--- a/lib/bh.js
+++ b/lib/bh.js
@@ -549,6 +549,7 @@ function BH() {
 }
 
 BH.prototype = {
+    contructor: BH,
 
     /**
      * Задает опции шаблонизации.


### PR DESCRIPTION
Привет!

Нам нужен отдельный инстанс bh, но так получилось, что мы везде провайдим и реквайрим именно инстанс `bh`, а не `BH`.

 Самый простой и (в меру) некостыльный способ для нас - использовать конструктор объекта `bh`, который должен быть равен `BH`. Но он равен `Object`, тк `BH.prototype` присваивается одним объектом, и там нет явного указания `constructor`.
